### PR TITLE
Fixed small syntax error in PyMC_LDA.ipynb

### DIFF
--- a/PyMC_LDA.ipynb
+++ b/PyMC_LDA.ipynb
@@ -120,7 +120,7 @@
     "                       if i != j]\n",
     "        return sorted(kldivs_docs, key=lambda x: x[3], reverse=True)\n",
     "    \n",
-    "    def show_topic_words(self, n=10, idwords):\n",
+    "    def show_topic_words(self, idwords, n=10):\n",
     "        for i, t in enumerate(self.phi.value):\n",
     "            print \"Topic %i : \" % i, \", \".join(idwords[w_] for w_ in np.argsort(t[0])[-10:] if w_ < (self.vocab-1-1))\n",
     "    \n",


### PR DESCRIPTION
Prior to fix returns error:

File "<ipython-input-42-f08bbc70fdc3>", line 60
    def show_topic_words(self, n=10, idwords):
SyntaxError: non-default argument follows default argument
